### PR TITLE
Robust Portfolio Excel Parsing

### DIFF
--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -156,6 +156,56 @@ function displayResults(grandTotal, rows) {
 }
 
 /**
+ * Parse Portfolio Data from raw rows (2D array)
+ */
+function parsePortfolioData(rows) {
+    let isinIdx = -1;
+    let qtyIdx = -1;
+    let headerRowIdx = -1;
+
+    const isinHeaders = ['isin', 'isin code'];
+    const qtyHeaders = ['quantity'];
+
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        if (!Array.isArray(row)) continue;
+
+        for (let j = 0; j < row.length; j++) {
+            const cell = String(row[j] || '').toLowerCase().trim();
+            if (isinIdx === -1 && isinHeaders.includes(cell)) {
+                isinIdx = j;
+            }
+            if (qtyIdx === -1 && qtyHeaders.includes(cell)) {
+                qtyIdx = j;
+            }
+        }
+
+        if (isinIdx !== -1 && qtyIdx !== -1) {
+            headerRowIdx = i;
+            break;
+        } else {
+            isinIdx = -1;
+            qtyIdx = -1;
+        }
+    }
+
+    if (headerRowIdx === -1) return [];
+
+    const data = [];
+    for (let i = headerRowIdx + 1; i < rows.length; i++) {
+        const row = rows[i];
+        if (!row) continue;
+        const isin = String(row[isinIdx] || '').trim();
+        const quantity = parseFloat(row[qtyIdx]);
+
+        if (isin && !isNaN(quantity) && isin.toLowerCase() !== 'nil') {
+            data.push({ isin, quantity });
+        }
+    }
+    return data;
+}
+
+/**
  * Handle File Upload
  */
 fileInput.addEventListener('change', (e) => {
@@ -175,12 +225,9 @@ fileInput.addEventListener('change', (e) => {
 
         lastFetchedSheetName = sheetName;
         const worksheet = workbook.Sheets[sheetName];
-        const jsonData = XLSX.utils.sheet_to_json(worksheet);
+        const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
 
-        portfolioData = jsonData.map(row => ({
-            isin: row['ISIN'],
-            quantity: parseFloat(row['Quantity'])
-        })).filter(item => item.isin && !isNaN(item.quantity));
+        portfolioData = parsePortfolioData(rows);
 
         if (portfolioData.length === 0) {
             resultDiv.innerHTML = '<span class="negative">No valid data found in ISIN and Quantity columns.</span>';

--- a/docs/live-valuation/logic.test.js
+++ b/docs/live-valuation/logic.test.js
@@ -23,6 +23,53 @@ function calculatePercentChange(current, saved) {
     return ((current - saved) / saved) * 100;
 }
 
+function parsePortfolioData(rows) {
+    let isinIdx = -1;
+    let qtyIdx = -1;
+    let headerRowIdx = -1;
+
+    const isinHeaders = ['isin', 'isin code'];
+    const qtyHeaders = ['quantity'];
+
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        if (!Array.isArray(row)) continue;
+
+        for (let j = 0; j < row.length; j++) {
+            const cell = String(row[j] || '').toLowerCase().trim();
+            if (isinIdx === -1 && isinHeaders.includes(cell)) {
+                isinIdx = j;
+            }
+            if (qtyIdx === -1 && qtyHeaders.includes(cell)) {
+                qtyIdx = j;
+            }
+        }
+
+        if (isinIdx !== -1 && qtyIdx !== -1) {
+            headerRowIdx = i;
+            break;
+        } else {
+            isinIdx = -1;
+            qtyIdx = -1;
+        }
+    }
+
+    if (headerRowIdx === -1) return [];
+
+    const data = [];
+    for (let i = headerRowIdx + 1; i < rows.length; i++) {
+        const row = rows[i];
+        if (!row) continue;
+        const isin = String(row[isinIdx] || '').trim();
+        const quantity = parseFloat(row[qtyIdx]);
+
+        if (isin && !isNaN(quantity) && isin.toLowerCase() !== 'nil') {
+            data.push({ isin, quantity });
+        }
+    }
+    return data;
+}
+
 // Test Runner
 let passed = 0;
 let failed = 0;
@@ -63,6 +110,53 @@ console.log("── Live Valuation Logic Tests ──");
     assert(calculatePercentChange(110, 100) === 10, "100 -> 110 should be 10%");
     assert(calculatePercentChange(90, 100) === -10, "100 -> 90 should be -10%");
     assert(calculatePercentChange(100, 100) === 0, "100 -> 100 should be 0%");
+}
+
+// 3. Portfolio Parsing Tests
+{
+    // Case 1: Standard headers on first row
+    const rows1 = [
+        ['ISIN', 'Quantity'],
+        ['INF209K01157', 100],
+        ['INF209K01165', 50]
+    ];
+    const data1 = parsePortfolioData(rows1);
+    assert(data1.length === 2, "Should parse 2 rows with standard headers on first row");
+    assert(data1[0].isin === 'INF209K01157' && data1[0].quantity === 100, "First row data should match");
+
+    // Case 2: Headers on 5th row
+    const rows2 = [
+        ['Portfolio Report'],
+        [],
+        ['Date: 2026-04-13'],
+        [],
+        ['ISIN', 'Other Column', 'Quantity'],
+        ['INF209K01157', 'PPLCF', 100],
+        ['INF209K01165', 'PPLCF', 50]
+    ];
+    const data2 = parsePortfolioData(rows2);
+    assert(data2.length === 2, "Should parse 2 rows with headers on 5th row");
+    assert(data2[1].isin === 'INF209K01165' && data2[1].quantity === 50, "Second row data should match");
+
+    // Case 3: Alias "ISIN Code"
+    const rows3 = [
+        ['ISIN Code', 'Quantity'],
+        ['INF209K01157', 100]
+    ];
+    const data3 = parsePortfolioData(rows3);
+    assert(data3.length === 1 && data3[0].isin === 'INF209K01157', "Should handle 'ISIN Code' alias");
+
+    // Case 4: Handle "NIL" and invalid quantities
+    const rows4 = [
+        ['ISIN', 'Quantity'],
+        ['NIL', 'NIL'],
+        ['INF209K01157', 100],
+        ['', 50],
+        ['INF209K01165', 'abc']
+    ];
+    const data4 = parsePortfolioData(rows4);
+    assert(data4.length === 1, "Should filter out NIL, empty ISIN, and invalid quantity");
+    assert(data4[0].isin === 'INF209K01157', "Only valid row should be INF209K01157");
 }
 
 console.log("\n─────────────────────────────────────────");


### PR DESCRIPTION
This change improves the robustness of the portfolio valuation tool's Excel parsing. Previously, the tool assumed headers were always on the first row and used fixed names. Now, it scans all rows to find the header row and supports aliases like "ISIN Code", making it compatible with more report formats.

---
*PR created automatically by Jules for task [6530416481136446037](https://jules.google.com/task/6530416481136446037) started by @yashgandhi143-collab*