### PR TITLE
2PM Cutoff and Enhanced ISIN Valuation via FMP API

### DIFF
--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -17,6 +17,7 @@ let isinToSymbolMap = null;
 const PROXY_URL = 'https://api.allorigins.win/raw?url=';
 const NSE_CSV_URL = 'https://nsearchives.nseindia.com/content/equities/EQUITY_L.csv';
 const FMP_PROFILE_URL = 'https://financialmodelingprep.com/stable/profile?symbol=';
+const FMP_ISIN_URL = 'https://financialmodelingprep.com/stable/search-isin?isin=';
 
 /**
  * Check if current time is within Indian Market Hours (9:15 AM - 3:30 PM IST)
@@ -35,7 +36,7 @@ function isMarketOpen() {
 
     const currentTimeInMinutes = hours * 60 + minutes;
     const marketOpenTimeInMinutes = 9 * 60 + 15;
-    const marketCloseTimeInMinutes = 15 * 60 + 30;
+    const marketCloseTimeInMinutes = 14 * 60; // 2:00 PM IST
 
     return currentTimeInMinutes >= marketOpenTimeInMinutes && currentTimeInMinutes <= marketCloseTimeInMinutes;
 }
@@ -80,14 +81,32 @@ async function fetchISINMapping() {
 }
 
 /**
- * Get Ticker from ISIN using NSE Mapping
+ * Get Ticker from ISIN using FMP Search and NSE Mapping fallback
  */
 async function getTicker(isin) {
+    const apiKey = apiKeyInput.value.trim();
+
+    // Try FMP ISIN Search first (supports global stocks)
+    if (apiKey) {
+        try {
+            const fmpResponse = await fetch(`${FMP_ISIN_URL}${isin}&apikey=${apiKey}`);
+            if (fmpResponse.ok) {
+                const data = await fmpResponse.json();
+                if (data && data.length > 0 && data[0].symbol) {
+                    return data[0].symbol;
+                }
+            }
+        } catch (error) {
+            console.warn(`FMP ISIN search failed for ${isin}, falling back to NSE list:`, error);
+        }
+    }
+
+    // Fallback to NSE ISIN mapping
     const mapping = await fetchISINMapping();
     if (mapping[isin]) {
         return mapping[isin];
     }
-    throw new Error(`Symbol not found for ISIN ${isin} in NSE list`);
+    throw new Error(`Symbol not found for ISIN ${isin}`);
 }
 
 /**
@@ -98,7 +117,7 @@ async function fetchPrice(ticker) {
     if (!apiKey) throw new Error('FMP API Key is required');
 
     try {
-        const response = await fetch(`${PROXY_URL}${encodeURIComponent(`${FMP_PROFILE_URL}${ticker}&apikey=${apiKey}`)}`);
+        const response = await fetch(`${FMP_PROFILE_URL}${ticker}&apikey=${apiKey}`);
         if (!response.ok) throw new Error(`Price API returned ${response.status}`);
         const data = await response.json();
         if (data && data.length > 0 && data[0].price !== undefined) {

--- a/docs/live-valuation/logic.test.js
+++ b/docs/live-valuation/logic.test.js
@@ -13,7 +13,7 @@ function isMarketOpenAt(date) {
 
     const currentTimeInMinutes = hours * 60 + minutes;
     const marketOpenTimeInMinutes = 9 * 60 + 15;
-    const marketCloseTimeInMinutes = 15 * 60 + 30;
+    const marketCloseTimeInMinutes = 14 * 60; // 2:00 PM IST
 
     return currentTimeInMinutes >= marketOpenTimeInMinutes && currentTimeInMinutes <= marketCloseTimeInMinutes;
 }
@@ -96,9 +96,9 @@ console.log("── Live Valuation Logic Tests ──");
     const mon9amIST = new Date('2026-03-09T03:30:00Z');
     assert(isMarketOpenAt(mon9amIST) === false, "Market should be closed at 9:00 AM IST on Monday");
 
-    // Monday 3:45 PM IST -> UTC 10:15 AM
-    const mon345pmIST = new Date('2026-03-09T10:15:00Z');
-    assert(isMarketOpenAt(mon345pmIST) === false, "Market should be closed at 3:45 PM IST on Monday");
+    // Monday 2:15 PM IST -> UTC 8:45 AM
+    const mon215pmIST = new Date('2026-03-09T08:45:00Z');
+    assert(isMarketOpenAt(mon215pmIST) === false, "Market should be closed at 2:15 PM IST on Monday");
 
     // Sunday 12:00 PM IST -> UTC 6:30 AM
     const sun12pmIST = new Date('2026-03-08T06:30:00Z');

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -53,7 +53,7 @@ function parseCSV(text) {
 async function fetchPrice(symbol, apiKey) {
     const ticker = `${symbol}.NS`;
     try {
-        const response = await fetch(`${PROXY_URL}${encodeURIComponent(`${FMP_PROFILE_URL}${ticker}&apikey=${apiKey}`)}`);
+        const response = await fetch(`${FMP_PROFILE_URL}${ticker}&apikey=${apiKey}`);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
         if (data && data.length > 0 && data[0].price !== undefined) {


### PR DESCRIPTION
This change addresses the user's request to track portfolio valuation during market hours with a specific 2:00 PM IST cutoff for same-day investment decisions. 

Key improvements:
1. **Market Hours**: The valuation tool now respects a 2:00 PM IST (14:00) cutoff as requested.
2. **Robust ISIN Mapping**: By integrating the FMP ISIN Search API (`/stable/search-isin`), the tool can now correctly identify and value international securities (like Alphabet or Microsoft held by Parag Parikh funds) which were previously missing from the NSE-only mapping list.
3. **Performance & Reliability**: FMP API calls now bypass the `allorigins.win` proxy, communicating directly with the browser via native CORS support. This resolves "failure errors" caused by proxy rate limits or timeouts.
4. **Maintenance**: Updated `logic.test.js` ensures the new market hours are correctly validated.

---
*PR created automatically by Jules for task [10140166615506257749](https://jules.google.com/task/10140166615506257749) started by @yashgandhi143-collab*