### PR TITLE
Implement mutual fund holding impact and price caching

### DIFF
--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -15,7 +15,7 @@ let isinToSymbolMap = null;
 
 // Proxy and API configuration
 const NSE_CSV_URL = '../assets/EQUITY_L.csv';
-const FMP_PROFILE_URL = 'https://financialmodelingprep.com/stable/profile?symbol=';
+const FMP_QUOTE_URL = 'https://financialmodelingprep.com/stable/quote?symbol=';
 const FMP_ISIN_URL = 'https://financialmodelingprep.com/stable/search-isin?isin=';
 
 /**
@@ -109,18 +109,36 @@ async function getTicker(isin) {
 }
 
 /**
- * Fetch Current Market Price for a Ticker
+ * Fetch Current Market Price for a Ticker with 1-hour caching
  */
 async function fetchPrice(ticker) {
     const apiKey = apiKeyInput.value.trim();
     if (!apiKey) throw new Error('FMP API Key is required');
 
+    const cacheKey = `price_${ticker}`;
+    const cachedData = localStorage.getItem(cacheKey);
+
+    if (cachedData) {
+        const { price, changesPercentage, timestamp } = JSON.parse(cachedData);
+        const oneHour = 60 * 60 * 1000;
+        if (Date.now() - timestamp < oneHour) {
+            console.log(`Using cached price for ${ticker}`);
+            return { price, changesPercentage, fromCache: true };
+        }
+    }
+
     try {
-        const response = await fetch(`${FMP_PROFILE_URL}${ticker}&apikey=${apiKey}`);
+        const response = await fetch(`${FMP_QUOTE_URL}${ticker}&apikey=${apiKey}`);
         if (!response.ok) throw new Error(`Price API returned ${response.status}`);
         const data = await response.json();
         if (data && data.length > 0 && data[0].price !== undefined) {
-            return data[0].price;
+            const priceData = {
+                price: data[0].price,
+                changesPercentage: data[0].changesPercentage || 0,
+                timestamp: Date.now()
+            };
+            localStorage.setItem(cacheKey, JSON.stringify(priceData));
+            return { ...priceData, fromCache: false };
         }
         throw new Error('Price data not available');
     } catch (error) {
@@ -151,19 +169,17 @@ async function updateValuation() {
         displayResults(calculateGrandTotal(portfolioData), portfolioData);
 
         try {
-            // Rate limiting: wait 500ms between requests
-            await delay(500);
-
             let ticker = item.ticker;
             if (!ticker) {
                 ticker = await getTicker(item.isin);
                 item.ticker = ticker; // Cache it
             }
 
-            const price = await fetchPrice(ticker);
+            const { price, changesPercentage, fromCache } = await fetchPrice(ticker);
 
             if (price !== null) {
                 item.price = price;
+                item.changesPercentage = changesPercentage;
                 item.total = item.quantity * price;
                 item.status = 'Success';
             } else {
@@ -171,6 +187,10 @@ async function updateValuation() {
                 item.status = 'Error';
                 item.error = 'Price not available';
             }
+
+            // Rate limiting: wait 500ms between requests ONLY if we didn't use cache
+            if (!fromCache) await delay(500);
+
         } catch (error) {
             console.error(`Error updating valuation for ${item.isin}:`, error);
             item.total = 0;
@@ -178,7 +198,19 @@ async function updateValuation() {
             item.error = error.message;
         }
 
-        displayResults(calculateGrandTotal(portfolioData), portfolioData);
+        // Recalculate weights and impacts based on CURRENT total of successfully fetched items
+        const currentGrandTotal = calculateGrandTotal(portfolioData);
+        portfolioData.forEach(row => {
+            if (row.status === 'Success' && currentGrandTotal > 0) {
+                row.weightage = (row.total / currentGrandTotal) * 100;
+                row.impact = (row.weightage / 100) * row.changesPercentage;
+            } else {
+                row.weightage = 0;
+                row.impact = 0;
+            }
+        });
+
+        displayResults(currentGrandTotal, portfolioData);
     }
 }
 
@@ -213,9 +245,16 @@ function displayResults(grandTotal, rows) {
         `;
     }
 
+    const totalImpact = rows.reduce((acc, row) => acc + (row.impact || 0), 0);
+    const impactClass = totalImpact >= 0 ? 'positive' : 'negative';
+    const impactSign = totalImpact >= 0 ? '+' : '';
+
     resultDiv.innerHTML = `
         <div class="valuation-header">
             ${lastFetchedSheetName} - Current Valuation: ₹${grandTotal.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+            <span class="${impactClass}" style="margin-left: 10px; font-size: 0.9rem;">
+                (${impactSign}${totalImpact.toFixed(2)}% Impact)
+            </span>
         </div>
         ${comparisonHtml}
     `;
@@ -226,10 +265,12 @@ function displayResults(grandTotal, rows) {
                 <tr>
                     <th>ISIN</th>
                     <th>Ticker</th>
-                    <th>Quantity</th>
+                    <th>Qty</th>
                     <th>CMP</th>
-                    <th>Row Total</th>
-                    <th>Status / Error</th>
+                    <th>Weight (%)</th>
+                    <th>Day Chg (%)</th>
+                    <th>Impact (%)</th>
+                    <th>Status</th>
                 </tr>
             </thead>
             <tbody>
@@ -244,8 +285,10 @@ function displayResults(grandTotal, rows) {
                 <td>${row.isin}</td>
                 <td>${row.ticker || 'N/A'}</td>
                 <td>${row.quantity}</td>
-                <td>${(row.price != null && row.price !== 'N/A') ? '₹' + row.price.toLocaleString('en-IN', { minimumFractionDigits: 2 }) : 'N/A'}</td>
-                <td>${(row.total != null && row.total !== 'N/A' && row.status === 'Success') ? '₹' + row.total.toLocaleString('en-IN', { minimumFractionDigits: 2 }) : 'N/A'}</td>
+                <td>${(row.price != null) ? '₹' + row.price.toLocaleString('en-IN', { minimumFractionDigits: 2 }) : 'N/A'}</td>
+                <td>${(row.weightage != null && row.status === 'Success') ? row.weightage.toFixed(2) + '%' : 'N/A'}</td>
+                <td>${(row.changesPercentage != null && row.status === 'Success') ? row.changesPercentage.toFixed(2) + '%' : 'N/A'}</td>
+                <td>${(row.impact != null && row.status === 'Success') ? row.impact.toFixed(4) + '%' : 'N/A'}</td>
                 <td class="${statusClass}">${displayStatus}</td>
             </tr>
         `;
@@ -255,8 +298,13 @@ function displayResults(grandTotal, rows) {
             </tbody>
             <tfoot>
                 <tr style="font-weight: bold; background-color: #f9f9f9;">
+                    <td colspan="4" style="text-align: right;">Total Portfolio Impact:</td>
+                    <td colspan="3" class="${impactClass}">${impactSign}${totalImpact.toFixed(2)}%</td>
+                    <td></td>
+                </tr>
+                <tr style="font-weight: bold; background-color: #f9f9f9;">
                     <td colspan="4" style="text-align: right;">Grand Total:</td>
-                    <td>₹${grandTotal.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                    <td colspan="3">₹${grandTotal.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
                     <td></td>
                 </tr>
             </tfoot>

--- a/docs/live-valuation/logic.test.js
+++ b/docs/live-valuation/logic.test.js
@@ -23,6 +23,20 @@ function calculatePercentChange(current, saved) {
     return ((current - saved) / saved) * 100;
 }
 
+function calculateWeightageAndImpact(portfolio) {
+    const total = portfolio.reduce((acc, item) => acc + (item.quantity * item.price), 0);
+    portfolio.forEach(item => {
+        if (total > 0) {
+            item.weightage = (item.quantity * item.price / total) * 100;
+            item.impact = (item.weightage / 100) * item.changesPercentage;
+        } else {
+            item.weightage = 0;
+            item.impact = 0;
+        }
+    });
+    return portfolio;
+}
+
 function parsePortfolioData(rows) {
     let isinIdx = -1;
     let qtyIdx = -1;
@@ -157,6 +171,36 @@ console.log("── Live Valuation Logic Tests ──");
     const data4 = parsePortfolioData(rows4);
     assert(data4.length === 1, "Should filter out NIL, empty ISIN, and invalid quantity");
     assert(data4[0].isin === 'INF209K01157', "Only valid row should be INF209K01157");
+}
+
+// 4. Weightage and Impact Tests
+{
+    const portfolio = [
+        { isin: 'A', quantity: 10, price: 100, changesPercentage: 10 }, // Value: 1000
+        { isin: 'B', quantity: 20, price: 50,  changesPercentage: -5 }, // Value: 1000
+    ];
+    // Total Value: 2000
+    // Weight A: 50%, Impact A: 5%
+    // Weight B: 50%, Impact B: -2.5%
+    // Total Impact: 2.5%
+
+    calculateWeightageAndImpact(portfolio);
+
+    assert(portfolio[0].weightage === 50, "Weightage of A should be 50%");
+    assert(portfolio[0].impact === 5, "Impact of A should be 5%");
+    assert(portfolio[1].weightage === 50, "Weightage of B should be 50%");
+    assert(portfolio[1].impact === -2.5, "Impact of B should be -2.5%");
+
+    const totalImpact = portfolio.reduce((acc, item) => acc + item.impact, 0);
+    assert(totalImpact === 2.5, "Total Impact should be 2.5%");
+
+    // Test with zero total
+    const zeroPortfolio = [
+        { isin: 'A', quantity: 0, price: 100, changesPercentage: 10 }
+    ];
+    calculateWeightageAndImpact(zeroPortfolio);
+    assert(zeroPortfolio[0].weightage === 0, "Weightage should be 0 for zero total");
+    assert(zeroPortfolio[0].impact === 0, "Impact should be 0 for zero total");
 }
 
 console.log("\n─────────────────────────────────────────");


### PR DESCRIPTION
This change implements the daily performance impact calculation for mutual fund holdings. 

Key enhancements:
1. **FMP Quote API Integration**: Updated the data fetching logic to use the `/stable/quote` endpoint, which provides both current market price and daily percentage changes.
2. **1-Hour Price Caching**: Successfully fetched price data is now stored in `localStorage` for 1 hour. This significantly speeds up subsequent loads and protects against API rate limits.
3. **Weightage & Impact Calculation**:
   - **Weightage**: Dynamically calculated as (Market Value of Holding / Total Portfolio Market Value) * 100.
   - **Impact**: Calculated as (Weightage / 100) * Day Change %.
   - Calculations are updated incrementally as prices are fetched.
4. **Enhanced UI**:
   - Added columns for "Weight (%)", "Day Chg (%)", and "Impact (%)".
   - Added a "Total Portfolio Impact" summary to the valuation header and table footer.
5. **Optimized Performance**: The mandatory 500ms delay between API calls is now bypassed if the data is available in the local cache.
6. **Robust Testing**: Added unit tests for the new calculation logic and verified frontend changes with visual regression checks.

---
*PR created automatically by Jules for task [11164169960079469191](https://jules.google.com/task/11164169960079469191) started by @yashgandhi143-collab*