### PR TITLE
Robust Market Price Fetching and Parsing

### DIFF
--- a/docs/live-valuation/API_GUIDE.md
+++ b/docs/live-valuation/API_GUIDE.md
@@ -5,45 +5,40 @@ This document explains how the Live Portfolio Valuation tool fetches market data
 ## Overview
 
 The tool uses a two-step process to get the Current Market Price (CMP) for a security given its ISIN:
-1. **ISIN to Ticker**: Maps the ISIN code (e.g., `INF209K01157`) to a Yahoo Finance Ticker symbol (e.g., `PARAGPARIKH.NS`).
+1. **ISIN to Ticker**: Maps the ISIN code (e.g., `INE002A01018`) to a Ticker symbol (e.g., `RELIANCE.NS`).
 2. **Ticker to Price**: Fetches the latest price for that Ticker.
 
 ## APIs Used
 
-### 1. Yahoo Finance Search API
-Used to find the ticker symbol for a given ISIN.
+### 1. Indian Stock Market Search API
+Used to find the ticker symbol for a given ISIN if not found in the local mapping.
 
-- **URL**: `https://query2.finance.yahoo.com/v1/finance/search?q={ISIN}`
+- **URL**: `https://nse-api-ruby.vercel.app/search?q={ISIN}`
 - **Method**: GET
-- **Response**: A JSON object containing a `quotes` array. The first quote's `symbol` is used.
+- **Response**: A JSON object containing a `results` array.
 
-### 2. Financial Modeling Prep Profile API
+### 2. Indian Stock Market Stock API
 Used to get the real-time market price for a ticker symbol.
 
-- **URL**: `https://financialmodelingprep.com/stable/profile?symbol={TICKER}&apikey={API_KEY}`
+- **URL**: `https://nse-api-ruby.vercel.app/stock?symbol={TICKER}&res=num`
 - **Method**: GET
-- **Response**: A JSON array containing an object with a `price` property. We use `data[0].price`.
+- **Response**: A JSON object containing a `data` object with properties like `last_price` and `percent_change`.
 
-**Note**: The API Key is provided by the user via the input field in the tool's interface.
+## ISIN Mapping Fallback
 
-## CORS Proxy
-
-Since these APIs do not support CORS (Cross-Origin Resource Sharing) for direct browser requests, we use a proxy:
-
-- **Proxy**: `https://api.allorigins.win/raw?url=`
-- **Usage**: The target API URL is encoded and appended to the proxy URL.
+The tool also uses a local file `docs/assets/EQUITY_L.csv` to map ISINs to symbols. This is the primary method for resolving ISINs.
 
 ## Rate Limiting and Performance
 
-To avoid being blocked by Yahoo Finance or the proxy, the following measures are implemented:
-- **Delay**: A 500ms delay is introduced between sequential API calls.
-- **Caching**: Ticker symbols are cached in memory once fetched for an ISIN.
+To avoid being blocked or rate limited, the following measures are implemented:
+- **Delay**: A 200ms delay is introduced between sequential API calls.
+- **Caching**: Ticker symbols and price data (valid for 1 hour) are cached in the browser's `localStorage`.
 - **Incremental Updates**: The UI updates row-by-row as prices are received.
 
 ## Error Handling
 
 The tool provides simplified error messages in the "Status / Error" column:
-- **"Symbol not found for this ISIN"**: The Search API couldn't find a matching ticker.
-- **"Price data not available"**: The Profile API returned no price data for the ticker.
-- **"API returned 429"**: Too many requests (Rate Limited).
+- **"Ticker not found"**: Both the Search API and local mapping failed to find a matching ticker.
+- **"Price not available"**: The Stock API returned no price data for the ticker.
+- **"API returned {status}"**: The API returned an error status (e.g., 500).
 - **"Network Error"**: Connection issues.

--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -104,12 +104,18 @@ async function getTicker(isin) {
 }
 
 /**
- * Update the valuation results using Batch API
+ * Update the valuation results by fetching latest prices
  */
 async function updateValuation() {
     if (portfolioData.length === 0) return;
 
     resultDiv.innerHTML = 'Refreshing prices...';
+
+    // Helper to robustly extract numeric values from API response
+    const extractValue = (obj, key) => {
+        if (!obj || obj[key] === undefined || obj[key] === null) return null;
+        return (typeof obj[key] === 'object' && obj[key].value !== undefined) ? obj[key].value : obj[key];
+    };
 
     // 1. Resolve all tickers first
     for (const item of portfolioData) {
@@ -164,23 +170,35 @@ async function updateValuation() {
                 const data = await response.json();
 
                 if (data.status === 'success' && data.data) {
-                    const stock = data.data;
-                    const priceData = {
-                        price: stock.last_price,
-                        changesPercentage: stock.percent_change,
-                        timestamp: Date.now()
-                    };
-                    localStorage.setItem(`price_${ticker}`, JSON.stringify(priceData));
+                    // Handle potential double-nesting and robustly extract values
+                    let stock = data.data;
+                    if (stock.data && (stock.data.last_price !== undefined || stock.data.percent_change !== undefined)) {
+                        stock = stock.data;
+                    }
 
-                    // Update all items in portfolio with this ticker
-                    portfolioData.forEach(item => {
-                        if (item.ticker === ticker) {
-                            item.price = stock.last_price;
-                            item.changesPercentage = stock.percent_change;
-                            item.total = item.quantity * item.price;
-                            item.status = 'Success';
-                        }
-                    });
+                    const lastPrice = extractValue(stock, 'last_price');
+                    const percentChange = extractValue(stock, 'percent_change');
+
+                    if (lastPrice !== null) {
+                        const priceData = {
+                            price: lastPrice,
+                            changesPercentage: percentChange || 0,
+                            timestamp: Date.now()
+                        };
+                        localStorage.setItem(`price_${ticker}`, JSON.stringify(priceData));
+
+                        // Update all items in portfolio with this ticker
+                        portfolioData.forEach(item => {
+                            if (item.ticker === ticker) {
+                                item.price = lastPrice;
+                                item.changesPercentage = percentChange || 0;
+                                item.total = item.quantity * item.price;
+                                item.status = 'Success';
+                            }
+                        });
+                    } else {
+                        throw new Error('Price data missing in response');
+                    }
                 } else {
                     portfolioData.forEach(item => {
                         if (item.ticker === ticker && item.status === 'Fetching Price') {

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -54,8 +54,22 @@ async function fetchPrice(symbol) {
         const response = await fetch(`${API_BASE_URL}/stock?symbol=${ticker}&res=num`);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
-        if (data.status === 'success' && data.data && data.data.last_price !== undefined) {
-            return { price: data.data.last_price, status: 'Success' };
+
+        const extractValue = (obj, key) => {
+            if (!obj || obj[key] === undefined || obj[key] === null) return null;
+            return (typeof obj[key] === 'object' && obj[key].value !== undefined) ? obj[key].value : obj[key];
+        };
+
+        if (data.status === 'success' && data.data) {
+            let stock = data.data;
+            if (stock.data && (stock.data.last_price !== undefined || stock.data.percent_change !== undefined)) {
+                stock = stock.data;
+            }
+
+            const lastPrice = extractValue(stock, 'last_price');
+            if (lastPrice !== null) {
+                return { price: lastPrice, status: 'Success' };
+            }
         }
         return { price: null, status: 'Not Found' };
     } catch (error) {


### PR DESCRIPTION
This change improves the reliability of the live portfolio valuation tool by making the price fetching logic more resilient to variations in the API response format. Specifically, it now correctly handles both numeric values and object-wrapped values (e.g., `{"value": 1340.6}`) for stock prices and percentage changes. It also adds a safeguard for cases where the API might return double-nested data. The documentation has also been updated to match the current implementation.

---
*PR created automatically by Jules for task [10949620542979256327](https://jules.google.com/task/10949620542979256327) started by @yashgandhi143-collab*