### PR TITLE
Fix robust price fetching logic

### DIFF
--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -156,7 +156,14 @@ async function updateValuation() {
     // Helper to robustly extract numeric values from API response
     const extractValue = (obj, key) => {
         if (!obj || obj[key] === undefined || obj[key] === null) return null;
-        return (typeof obj[key] === 'object' && obj[key].value !== undefined) ? obj[key].value : obj[key];
+        let val = obj[key];
+        if (typeof val === 'object' && val.value !== undefined) {
+            val = val.value;
+        }
+        if (typeof val === 'string') {
+            val = parseFloat(val.replace(/,/g, ''));
+        }
+        return isNaN(val) ? null : val;
     };
 
     for (let i = 0; i < portfolioData.length; i++) {
@@ -198,14 +205,24 @@ async function updateValuation() {
                 const data = await response.json();
                 logToUI('response', `Price data for ${item.ticker}`, data);
 
-                if (data.status === 'success' && data.data) {
-                    let stock = data.data;
-                    if (stock.data && (stock.data.last_price !== undefined || stock.data.percent_change !== undefined)) {
-                        stock = stock.data;
+                if (data.status === 'success') {
+                    let stock = null;
+
+                    // Robustly find the stock data object in common API response structures
+                    if (data.data && data.data.last_price !== undefined) {
+                        stock = data.data;
+                    } else if (data.data && data.data.data && data.data.data.last_price !== undefined) {
+                        stock = data.data.data;
+                    } else if (Array.isArray(data.stocks) && data.stocks.length > 0) {
+                        stock = data.stocks[0];
+                    } else if (data.last_price !== undefined) {
+                        stock = data;
                     }
 
-                    lastPrice = extractValue(stock, 'last_price');
-                    percentChange = extractValue(stock, 'percent_change') || 0;
+                    if (stock) {
+                        lastPrice = extractValue(stock, 'last_price');
+                        percentChange = extractValue(stock, 'percent_change') || 0;
+                    }
 
                     if (lastPrice !== null) {
                         const priceData = {

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -57,16 +57,29 @@ async function fetchPrice(symbol) {
 
         const extractValue = (obj, key) => {
             if (!obj || obj[key] === undefined || obj[key] === null) return null;
-            return (typeof obj[key] === 'object' && obj[key].value !== undefined) ? obj[key].value : obj[key];
+            let val = obj[key];
+            if (typeof val === 'object' && val.value !== undefined) {
+                val = val.value;
+            }
+            if (typeof val === 'string') {
+                val = parseFloat(val.replace(/,/g, ''));
+            }
+            return isNaN(val) ? null : val;
         };
 
-        if (data.status === 'success' && data.data) {
-            let stock = data.data;
-            if (stock.data && (stock.data.last_price !== undefined || stock.data.percent_change !== undefined)) {
-                stock = stock.data;
+        if (data.status === 'success') {
+            let stock = null;
+            if (data.data && data.data.last_price !== undefined) {
+                stock = data.data;
+            } else if (data.data && data.data.data && data.data.data.last_price !== undefined) {
+                stock = data.data.data;
+            } else if (Array.isArray(data.stocks) && data.stocks.length > 0) {
+                stock = data.stocks[0];
+            } else if (data.last_price !== undefined) {
+                stock = data;
             }
 
-            const lastPrice = extractValue(stock, 'last_price');
+            const lastPrice = stock ? extractValue(stock, 'last_price') : null;
             if (lastPrice !== null) {
                 return { price: lastPrice, status: 'Success' };
             }


### PR DESCRIPTION
Fixed the issue where the live portfolio valuation tool failed to correctly extract stock prices from the API response. The fix includes:
1.  A more robust `extractValue` helper that can parse numeric strings with commas (e.g., "1,234.50") and handle object-wrapped values (e.g., `{ value: 1234.50 }`).
2.  Enhanced extraction logic that checks several common JSON structures used by the Indian Stock Market API, ensuring compatibility across different endpoints and versions.
3.  Consistency updates to the `test-prices.js` diagnostic tool.
4.  Verification via automated tests simulating various API response formats.

---
*PR created automatically by Jules for task [2130615284156837993](https://jules.google.com/task/2130615284156837993) started by @yashgandhi143-collab*