### PR TITLE
Use equityQuote and close price for valuation

### DIFF
--- a/docs/live-valuation/API_GUIDE.md
+++ b/docs/live-valuation/API_GUIDE.md
@@ -5,7 +5,7 @@ This document explains how the Live Portfolio Valuation tool fetches market data
 ## Overview
 
 The tool uses a two-step process to get the Current Market Price (CMP) for a security given its ISIN:
-1. **ISIN to Ticker**: Maps the ISIN code (e.g., `INE002A01018`) to a Ticker symbol (e.g., `RELIANCE.NS`).
+1. **ISIN to Ticker**: Maps the ISIN code (e.g., `INE002A01018`) to a Ticker symbol (e.g., `RELIANCE`).
 2. **Ticker to Price**: Fetches the latest price for that Ticker.
 
 ## APIs Used
@@ -17,12 +17,23 @@ Used to find the ticker symbol for a given ISIN if not found in the local mappin
 - **Method**: GET
 - **Response**: A JSON object containing a `results` array.
 
-### 2. Indian Stock Market Stock API
+### 2. Indian Stock Market Equity Quote API
 Used to get the real-time market price for a ticker symbol.
 
-- **URL**: `https://nse-api-ruby.vercel.app/stock?symbol={TICKER}&res=num`
+- **URL**: `https://nse-api-ruby.vercel.app/equityQuote?symbol={TICKER}`
 - **Method**: GET
-- **Response**: A JSON object containing a `data` object with properties like `last_price` and `percent_change`.
+- **Response**: A JSON object containing OCHLV data.
+  ```json
+  {
+    "date": "16-Oct-2023 16:00:00",
+    "open": 1432.1,
+    "high": 1443.6,
+    "low": 1430,
+    "close": 1434.15,
+    "volume": 4850745
+  }
+  ```
+  The tool uses the `close` field for the Current Market Price (CMP).
 
 ## ISIN Mapping Fallback
 

--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -99,7 +99,7 @@ async function fetchISINMapping() {
                 const symbol = cols[0].trim();
                 const isin = cols[6].trim();
                 if (symbol && isin) {
-                    mapping[isin] = symbol + '.NS';
+                    mapping[isin] = symbol;
                 }
             }
         }
@@ -125,7 +125,7 @@ async function getTicker(isin) {
             const data = await response.json();
             logToUI('response', `Search results for ${isin}`, data);
             if (data.status === 'success' && data.results && data.results.length > 0) {
-                return data.results[0].symbol + '.NS';
+                return data.results[0].symbol;
             }
         } else {
             logToUI('error', `Search API failed for ${isin}`, `Status: ${response.status}`);
@@ -196,7 +196,7 @@ async function updateValuation() {
                 item.status = 'Fetching Price';
                 displayResults(calculateGrandTotal(portfolioData), portfolioData);
 
-                const url = `${API_BASE_URL}/stock?symbol=${item.ticker}&res=num`;
+                const url = `${API_BASE_URL}/equityQuote?symbol=${item.ticker}`;
                 logToUI('request', `Fetching price for: ${item.ticker}`, url);
 
                 const response = await fetch(url);
@@ -205,38 +205,26 @@ async function updateValuation() {
                 const data = await response.json();
                 logToUI('response', `Price data for ${item.ticker}`, data);
 
-                if (data.status === 'success') {
-                    let stock = null;
-
-                    // Robustly find the stock data object in common API response structures
-                    if (data.data && data.data.last_price !== undefined) {
-                        stock = data.data;
-                    } else if (data.data && data.data.data && data.data.data.last_price !== undefined) {
-                        stock = data.data.data;
-                    } else if (Array.isArray(data.stocks) && data.stocks.length > 0) {
-                        stock = data.stocks[0];
-                    } else if (data.last_price !== undefined) {
-                        stock = data;
-                    }
-
-                    if (stock) {
-                        lastPrice = extractValue(stock, 'last_price');
-                        percentChange = extractValue(stock, 'percent_change') || 0;
-                    }
-
-                    if (lastPrice !== null) {
-                        const priceData = {
-                            price: lastPrice,
-                            changesPercentage: percentChange,
-                            timestamp: Date.now()
-                        };
-                        localStorage.setItem(cacheKey, JSON.stringify(priceData));
-                        item.status = 'Success';
-                    } else {
-                        throw new Error('Price data missing in response');
-                    }
+                // Use "close" for price as per user request
+                lastPrice = extractValue(data, 'close');
+                // Calculate percentage change if open and close are available
+                const openPrice = extractValue(data, 'open');
+                if (lastPrice !== null && openPrice !== null && openPrice !== 0) {
+                    percentChange = ((lastPrice - openPrice) / openPrice) * 100;
                 } else {
-                    throw new Error('Invalid API response structure');
+                    percentChange = 0;
+                }
+
+                if (lastPrice !== null) {
+                    const priceData = {
+                        price: lastPrice,
+                        changesPercentage: percentChange,
+                        timestamp: Date.now()
+                    };
+                    localStorage.setItem(cacheKey, JSON.stringify(priceData));
+                    item.status = 'Success';
+                } else {
+                    throw new Error('Price data (close) missing in response');
                 }
             }
 

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -49,9 +49,8 @@ function parseCSV(text) {
 }
 
 async function fetchPrice(symbol) {
-    const ticker = `${symbol}.NS`;
     try {
-        const response = await fetch(`${API_BASE_URL}/stock?symbol=${ticker}&res=num`);
+        const response = await fetch(`${API_BASE_URL}/equityQuote?symbol=${symbol}`);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
 
@@ -67,22 +66,10 @@ async function fetchPrice(symbol) {
             return isNaN(val) ? null : val;
         };
 
-        if (data.status === 'success') {
-            let stock = null;
-            if (data.data && data.data.last_price !== undefined) {
-                stock = data.data;
-            } else if (data.data && data.data.data && data.data.data.last_price !== undefined) {
-                stock = data.data.data;
-            } else if (Array.isArray(data.stocks) && data.stocks.length > 0) {
-                stock = data.stocks[0];
-            } else if (data.last_price !== undefined) {
-                stock = data;
-            }
-
-            const lastPrice = stock ? extractValue(stock, 'last_price') : null;
-            if (lastPrice !== null) {
-                return { price: lastPrice, status: 'Success' };
-            }
+        // Use "close" for price as per user request
+        const lastPrice = extractValue(data, 'close');
+        if (lastPrice !== null) {
+            return { price: lastPrice, status: 'Success' };
         }
         return { price: null, status: 'Not Found' };
     } catch (error) {


### PR DESCRIPTION
The 'Live Portfolio Valuation' tool has been updated to use the `equityQuote` endpoint and the `close` price field from the NSE API. This change includes:
- Updating `app.js` and `test-prices.js` to call the new `/equityQuote?symbol={symbol}` endpoint.
- Mapping ISINs to symbols without the `.NS` suffix.
- Extracting the `close` field for the stock price.
- Calculating the daily percentage change manually as `((close - open) / open) * 100`.
- Updating the documentation in `API_GUIDE.md`.
Logic tests have been run and passed, and visual verification was performed to ensure the UI remains functional.

---
*PR created automatically by Jules for task [16749276351624883374](https://jules.google.com/task/16749276351624883374) started by @yashgandhi143-collab*