### PR TITLE
Fix NSE API Fetch Error in Portfolio Valuation Tool

### DIFF
--- a/docs/live-valuation/API_GUIDE.md
+++ b/docs/live-valuation/API_GUIDE.md
@@ -10,10 +10,11 @@ The tool uses a two-step process to get the Current Market Price (CMP) for a sec
 
 ## APIs Used
 
-### 1. NSE India Equity Quote API
-Used to get the real-time market price and daily change for a ticker symbol.
+### 1. NSE India Equity Quote API (via CORS Proxy)
+Used to get the real-time market price and daily change for a ticker symbol. Due to CORS restrictions on the official NSE India domain, requests are routed through a CORS proxy.
 
-- **URL**: `https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ&symbol={TICKER}`
+- **Target URL**: `https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ&symbol={TICKER}`
+- **Proxy used**: `https://corsproxy.io/?url=`
 - **Method**: GET
 - **Response**: A JSON object containing an `equityResponse` array.
   ```json

--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -17,7 +17,8 @@ let isinToSymbolMap = null;
 
 // Proxy and API configuration
 const NSE_CSV_URL = '../assets/EQUITY_L.csv';
-const API_BASE_URL = 'https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ';
+const NSE_API_URL = 'https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ';
+const CORS_PROXY = 'https://corsproxy.io/?url=';
 
 /**
  * Check if current time is within Indian Market Hours (9:15 AM - 3:30 PM IST)
@@ -178,11 +179,13 @@ async function updateValuation() {
                 item.status = 'Fetching Price';
                 displayResults(calculateGrandTotal(portfolioData), portfolioData);
 
-                const url = `${API_BASE_URL}&symbol=${item.ticker}`;
-                logToUI('request', `Fetching price for: ${item.ticker}`, url);
+                const targetUrl = `${NSE_API_URL}&symbol=${item.ticker}`;
+                const proxyUrl = `${CORS_PROXY}${encodeURIComponent(targetUrl)}`;
 
-                const response = await fetch(url);
-                if (!response.ok) throw new Error(`API returned ${response.status}`);
+                logToUI('request', `Fetching price for: ${item.ticker}`, targetUrl);
+
+                const response = await fetch(proxyUrl);
+                if (!response.ok) throw new Error(`API returned ${response.status} through proxy`);
 
                 const data = await response.json();
                 logToUI('response', `Price data for ${item.ticker}`, data);
@@ -223,10 +226,10 @@ async function updateValuation() {
 
             // Small delay between requests to avoid rate limits
             if (i < portfolioData.length - 1) {
-                await delay(200);
+                await delay(1000);
             }
         } catch (error) {
-            logToUI('error', `Process failed for row ${i + 1}: ${error.message}`);
+            logToUI('error', `Process failed for row ${i + 1}: ${error.message}`, error.stack || error);
             item.status = 'Error';
             item.error = error.message;
             displayResults(calculateGrandTotal(portfolioData), portfolioData);

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -9,7 +9,8 @@ const summaryDiv = document.getElementById('summary');
 const resultsTableContainer = document.getElementById('resultsTableContainer');
 
 const NSE_CSV_URL = '../assets/EQUITY_L.csv';
-const API_BASE_URL = 'https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ';
+const NSE_API_URL = 'https://www.nseindia.com/api/NextApi/apiClient/GetQuoteApi?functionName=getSymbolData&marketType=N&series=EQ';
+const CORS_PROXY = 'https://corsproxy.io/?url=';
 
 let testResults = [];
 let successCount = 0;
@@ -50,8 +51,10 @@ function parseCSV(text) {
 
 async function fetchPrice(symbol) {
     try {
-        const response = await fetch(`${API_BASE_URL}&symbol=${symbol}`);
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const targetUrl = `${NSE_API_URL}&symbol=${symbol}`;
+        const proxyUrl = `${CORS_PROXY}${encodeURIComponent(targetUrl)}`;
+        const response = await fetch(proxyUrl);
+        if (!response.ok) throw new Error(`HTTP ${response.status} through proxy`);
         const data = await response.json();
 
         const extractValue = (obj, key) => {


### PR DESCRIPTION
The "Failed to fetch" error was caused by CORS restrictions when calling the NSE India API directly from the browser. I have implemented a fix using the `corsproxy.io` proxy service and increased the request delay to 1000ms to avoid rate-limiting. Verified the changes with unit tests and UI screenshots.

---
*PR created automatically by Jules for task [17610556992371503857](https://jules.google.com/task/17610556992371503857) started by @yashgandhi143-collab*