### PR TITLE
Increase API call delay to 3 seconds

### DIFF
--- a/docs/live-valuation/app.js
+++ b/docs/live-valuation/app.js
@@ -226,7 +226,7 @@ async function updateValuation() {
 
             // Small delay between requests to avoid rate limits
             if (i < portfolioData.length - 1) {
-                await delay(1000);
+                await delay(3000);
             }
         } catch (error) {
             logToUI('error', `Process failed for row ${i + 1}: ${error.message}`, error.stack || error);

--- a/docs/live-valuation/test-prices.js
+++ b/docs/live-valuation/test-prices.js
@@ -115,7 +115,7 @@ async function startTesting() {
             const stock = stocks[i];
 
             // Wait to avoid aggressive rate limiting
-            await delay(200);
+            await delay(3000);
 
             const result = await fetchPrice(stock.symbol);
 


### PR DESCRIPTION
Increased the sequential delay between NSE API calls to 3 seconds across both the main valuation app and the diagnostic price tester. This ensures more stable data retrieval and reduces the risk of being blocked by the API provider. Verified the changes with existing unit tests and manual inspection.

---
*PR created automatically by Jules for task [1935709560358189826](https://jules.google.com/task/1935709560358189826) started by @yashgandhi143-collab*